### PR TITLE
Reworked WoL from S5 implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     env:
       JOB_TYPE: BUILD
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: acidanthera/MacKernelSDK
           path: MacKernelSDK
@@ -33,13 +33,13 @@ jobs:
       - run: xcodebuild -jobs 1 -configuration Release
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts
           path: build/*/*.zip
       - name: Upload to Release
         if: github.event_name == 'release'
-        uses: svenstaro/upload-release-action@e74ff71f7d8a4c4745b560a485cc5fdb9b5b999d
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: build/*/*.zip
@@ -52,8 +52,8 @@ jobs:
     env:
       JOB_TYPE: ANALYZE
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: acidanthera/MacKernelSDK
           path: MacKernelSDK
@@ -74,8 +74,8 @@ jobs:
       JOB_TYPE: COVERITY
     if: github.repository_owner == 'acidanthera' && github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: acidanthera/MacKernelSDK
           path: MacKernelSDK

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@ IntelMausi Changelog
 #### v1.0.9
 - Reworked WoL from S5 implementation, thx @jpz4085:
   - WoL from S5 is now following macOS "Wake for network access" or pmset "womp" setting
-  - To disable it entirely at boot (regardless of macOS), add `mausi-disable-wol-from-s5` device property or `-mausinowols5` boot-arg
+  - To force-enable WoL use `mausi-wol-override=1`, to force-disable use `mausi-wol-override=0`
   - Removed `mausi-force-wol` device property and `-mausiwol` boot argument
 
 #### v1.0.8

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 IntelMausi Changelog
 ====================
+#### v1.0.9
+- Reworked WoL from S5 implementation, thx @jpz4085:
+  - WoL from S5 is now following macOS "Wake for network access" or pmset "womp" setting
+  - To disable it entirely at boot (regardless of macOS), add `mausi-disable-wol-from-s5` device property or `-mausinowols5` boot-arg
+  - Removed `mausi-force-wol` device property and `-mausiwol` boot argument
+
 #### v1.0.8
 - Minor fixes found by static analysis
 

--- a/IntelMausiEthernet/IntelMausiEthernet.cpp
+++ b/IntelMausiEthernet/IntelMausiEthernet.cpp
@@ -2586,7 +2586,7 @@ bool IntelMausi::intelStart()
          e1000e_get_hw_control(adapter);
      */
 
-    DebugLog("[IntelMausi]: %s (Rev. %u), %02x:%02x:%02x:%02x:%02x:%02x\n",
+    DebugLog("[IntelMausi]: %s (Rev. %u), %02X:%02X:%02X:%02X:%02X:%02X\n",
           deviceTable[chip].deviceName, pciDeviceData.revision,
           mac->addr[0], mac->addr[1], mac->addr[2], mac->addr[3], mac->addr[4], mac->addr[5]);
     result = true;

--- a/IntelMausiEthernet/IntelMausiEthernet.h
+++ b/IntelMausiEthernet/IntelMausiEthernet.h
@@ -447,6 +447,12 @@ private:
     /* timer action */
     void timerAction(IOTimerEventSource *timer);
 
+    /* Set wolActive prior to shutdown or restart to support WoL from S5
+     * if "Wake for network access" or "womp" is enabled and run the hardware
+     * enable/disable routines if the controller is already disabled.
+     */
+    void setWakeOnLanFromShutdown();
+
 private:
     IOWorkLoop *workLoop;
     IOCommandGate *commandGate;
@@ -542,6 +548,7 @@ private:
     bool forceReset;
     bool wolCapable;
     bool wolActive;
+    bool wolPwrOff;
     bool enableCSO6;
     bool enableWoM;
 

--- a/IntelMausiEthernet/IntelMausiEthernet.h
+++ b/IntelMausiEthernet/IntelMausiEthernet.h
@@ -448,7 +448,8 @@ private:
     void timerAction(IOTimerEventSource *timer);
 
     /* Set wolActive prior to shutdown or restart to support WoL from S5
-     * if "Wake for network access" or "womp" is enabled and run the hardware
+     * if "Wake for network access" or "womp" is enabled or mausi-wol-override=1
+     * is set via boot-args and run the hardware
      * enable/disable routines if the controller is already disabled.
      */
     void setWakeOnLanFromShutdown();

--- a/IntelMausiEthernet/IntelMausiEthernet.h
+++ b/IntelMausiEthernet/IntelMausiEthernet.h
@@ -549,6 +549,7 @@ private:
     bool wolCapable;
     bool wolActive;
     bool wolPwrOff;
+    bool mausiwoloverride;
     bool enableCSO6;
     bool enableWoM;
 

--- a/IntelMausiEthernet/IntelMausiHardware.cpp
+++ b/IntelMausiEthernet/IntelMausiHardware.cpp
@@ -1821,7 +1821,7 @@ void IntelMausi::intelInitPhyWakeup(UInt32 wufc, struct IntelAddrData *addrData)
         num = (addrData->ipV4Count > kMaxAddrV4) ? kMaxAddrV4 : addrData->ipV4Count;
 
         for (i = 0; i < num; i++) {
-            //av |= BIT(i + 1);
+            av |= BIT(i + 1);
             ad = addrData->ipV4Addr[i];
 
             hw->phy.ops.write_reg_page(hw, BM_IP4AT0(i), (u16)(ad & 0xFFFF));

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ as well as kernel debugging support initially provided by [aerror2](https://gith
 [IntelMausiEthernetWithKernelDebugger](https://github.com/aerror2/IntelMausiEthernetWithKernelDebugger)
 repository. Do use the original version when uncertain. No support or troubleshooting provided.
 
-Wake on LAN functionality should work out of the box. On misconfigured hardware one may try to force-enable it by injecting `mausi-force-wol` device property (with any value, recommended), or `-mausiwol` boot argument (for testing purposes).
+In macOS, Wake on LAN from sleep is controlled by the system setting "Wake for network access" or pmset "womp". The same is applied by default for WoL from shutdown. This feature can be disabled entirely at boot by injecting `mausi-disable-wol-from-s5` device property (with any value, recommended), or `-mausinowols5` boot argument (for testing purposes).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ as well as kernel debugging support initially provided by [aerror2](https://gith
 [IntelMausiEthernetWithKernelDebugger](https://github.com/aerror2/IntelMausiEthernetWithKernelDebugger)
 repository. Do use the original version when uncertain. No support or troubleshooting provided.
 
-In macOS, Wake on LAN from sleep is controlled by the system setting "Wake for network access" or pmset "womp". The same is applied by default for WoL from shutdown. This feature can be disabled entirely at boot by injecting `mausi-disable-wol-from-s5` device property (with any value, recommended), or `-mausinowols5` boot argument (for testing purposes).
+In macOS, Wake on LAN from sleep is controlled by the system setting "Wake for network access" or pmset "womp". The same is applied by default for WoL from shutdown.
+To force-enable WoL use `mausi-wol-override=1` boot-arg.
+To force-disable WoL use `mausi-wol-override=0` boot-arg.
 
 ---
 


### PR DESCRIPTION
In macOS, Wake on LAN feature is controlled by "Wake for network access" or "womp" setting.
With this pull request, Wake on LAN from shutdown is also macOS controlled. This make sure the feature is dynamically controlled by the OS.

Thanks to @jpz4085 for the better implementation! Ref: https://www.tonymacx86.com/posts/2178654

To disable the feature entirely at boot (regardless of whether "womp" is enabled/disabled), add `mausi-disable-wol-from-s5` device property or `-mausinowols5` boot-arg (takes precedence over the dev property).

Removed `mausi-force-wol` device property and `-mausiwol` boot argument